### PR TITLE
Remove fs as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 	"dependencies": {
 	"chai": "^3.5.0",
 	"cheerio": "^0.22.0",
-	"fs": "0.0.1-security",
 	"mocha": "^3.0.2",
 	"path": "^0.12.7",
 	"request": "^2.74.0",


### PR DESCRIPTION
Heya, this package on npm is a placeholder. Fs functionality is built-in so there's no need to put it in your list of dependencies. More info on this can be found here:

https://www.npmjs.com/package/fs
http://status.npmjs.org/incidents/dw8cr1lwxkcr